### PR TITLE
Fix the "double -1" bug with javascript months

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,12 +231,12 @@
               birthDay = dateOfBirth.getDate();
               age = todayYear - birthYear;
 
-              if (todayMonth < birthMonth - 1)
+              if (todayMonth < birthMonth)
               {
                 age--;
               }
 
-              if (birthMonth - 1 == todayMonth && todayDay < birthDay)
+              if (birthMonth == todayMonth && todayDay < birthDay)
               {
                 age--;
               }


### PR DESCRIPTION
The calculateAge function I took from the website stated subtracted 1 from the month as js is zero-based for months. I then changed the code to pass in a js date, so effectively became -2, making people a year older than they should be